### PR TITLE
Redirect to current URL after authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tesseral/tesseral-nextjs",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tesseral/tesseral-nextjs",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "dependencies": {
         "@tesseral/tesseral-node": "^0.0.17",
         "@tesseral/tesseral-vanilla-clientside": "^0.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tesseral/tesseral-nextjs",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "",
   "files": [
     "dist"

--- a/src/internal/clientside/default-mode-access-token-provider.tsx
+++ b/src/internal/clientside/default-mode-access-token-provider.tsx
@@ -46,7 +46,10 @@ function useAccessToken(): string {
       } catch (e) {
         if (e instanceof TesseralError && e.statusCode === 401) {
           // our refresh token is no good
-          redirect(`/_tesseral_next/redirect-login`);
+          const queryParams = new URLSearchParams({
+            "redirect-uri": window.location.href,
+          });
+          redirect(`/_tesseral_next/redirect-login?${queryParams.toString()}`);
         }
 
         setError(e);

--- a/src/internal/clientside/dev-mode-access-token-provider.tsx
+++ b/src/internal/clientside/dev-mode-access-token-provider.tsx
@@ -71,7 +71,10 @@ function useAccessToken(): string {
       } catch (e) {
         if (e instanceof TesseralError && e.statusCode === 401) {
           // our refresh token is no good
-          redirect(`/_tesseral_next/redirect-login`);
+          const queryParams = new URLSearchParams({
+            "redirect-uri": window.location.href,
+          });
+          redirect(`/_tesseral_next/redirect-login?${queryParams.toString()}`);
         }
 
         setError(e);

--- a/src/internal/middleware/dev-mode-callback.ts
+++ b/src/internal/middleware/dev-mode-callback.ts
@@ -12,9 +12,12 @@ export async function devModeCallback(req: NextRequest): Promise<NextResponse> {
     throw new Error(`No __tesseral_${projectId}_relayed_session_token found`);
   }
 
-  const redirectUrl = req.nextUrl.searchParams.get(`__tesseral_${projectId}_redirect_uri`);
+  let redirectUrl = req.nextUrl.searchParams.get(`redirect-uri`);
   if (!redirectUrl) {
-    throw new Error(`No __tesseral_${projectId}_redirect_uri found`);
+    redirectUrl = req.nextUrl.searchParams.get(`__tesseral_${projectId}_redirect_uri`);
+    if (!redirectUrl) {
+      throw new Error(`No __tesseral_${projectId}_redirect_uri found`);
+    }
   }
 
   const { refreshToken, accessToken, relayedSessionState } = await exchangeRelayedSessionToken({

--- a/src/internal/middleware/redirect-login.ts
+++ b/src/internal/middleware/redirect-login.ts
@@ -17,7 +17,10 @@ export async function redirectLogin(req: NextRequest): Promise<NextResponse> {
 
     const params = new URLSearchParams();
     params.set("relayed-session-state", relayedSessionState);
-    params.set("redirect-uri", `${req.nextUrl.protocol}//${req.nextUrl.host}/_tesseral_next/dev-mode-callback`);
+    params.set(
+      "redirect-uri",
+      `${req.nextUrl.protocol}//${req.nextUrl.host}/_tesseral_next/dev-mode-callback${req.nextUrl.search}`,
+    );
     params.set("return-relayed-session-token-as-query-param", "1");
 
     const redirectUrl = new URL(`https://${vaultDomain}/login`);
@@ -34,5 +37,5 @@ export async function redirectLogin(req: NextRequest): Promise<NextResponse> {
     return response;
   }
 
-  return NextResponse.redirect(`https://${vaultDomain}/login`);
+  return NextResponse.redirect(`https://${vaultDomain}/login?${req.nextUrl.search}`);
 }

--- a/src/internal/serverside/tesseral-provider.tsx
+++ b/src/internal/serverside/tesseral-provider.tsx
@@ -11,7 +11,10 @@ export async function TesseralProvider({ children }: { children?: React.ReactNod
     // If auth() is happy but there are no claims, then this is a request coming
     // from an API key. But TesseralProvider is only useful for browsers.
     // Redirect this request away.
-    redirect(`/_tesseral_next/redirect-login`);
+    const queryParams = new URLSearchParams({
+      "redirect-uri": window.location.href,
+    });
+    redirect(`/_tesseral_next/redirect-login?${queryParams.toString()}`);
   }
 
   return (


### PR DESCRIPTION
This PR updates the way that redirects are generated to include the current request URL as the `redirect-uri` query param of `_tesseral_next/redirect-login`. This param is then persisted through the login flow and popped back off when needed. In the case of dev-mode callbacks, we also include the current request in this URL and the dev-mode callback first checks for the plain `redirect-uri` param before failing over to the default param.

The end result is that users are redirected to the page they were attempting to visit after a successful login.