### PR TITLE
Preserve query parameters on dev-mode-callback

### DIFF
--- a/example/app/subpath/page.tsx
+++ b/example/app/subpath/page.tsx
@@ -1,0 +1,22 @@
+import { useState } from "react";
+
+import { auth, getOrganization, getUser } from "../../../src/serverside";
+
+export default async function Page() {
+  const organization = await getOrganization();
+  const user = await getUser();
+
+  return (
+    <div>
+      <div>React Server Component: getOrganization()</div>
+      <code>
+        <pre>{JSON.stringify(organization, null, 2)}</pre>
+      </code>
+
+      <div>React Server Component: getUser()</div>
+      <code>
+        <pre>{JSON.stringify(user, null, 2)}</pre>
+      </code>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@tesseral/tesseral-nextjs",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tesseral/tesseral-nextjs",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "dependencies": {
-        "@tesseral/tesseral-node": "^0.0.19",
-        "@tesseral/tesseral-vanilla-clientside": "^0.0.9",
+        "@tesseral/tesseral-node": "^0.0.17",
+        "@tesseral/tesseral-vanilla-clientside": "^0.0.8",
         "next": "^15.3.2"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tesseral/tesseral-nextjs",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "",
   "files": [
     "dist"

--- a/src/internal/middleware/dev-mode-callback.ts
+++ b/src/internal/middleware/dev-mode-callback.ts
@@ -34,7 +34,7 @@ export async function devModeCallback(req: NextRequest): Promise<NextResponse> {
 
   // To better handle localhost development, we only want to use the pathname of the redirect URL.
   const preferredRedirectUrl = new URL(redirectUrl);
-  const actualRedirectUrl = new URL(preferredRedirectUrl.pathname, req.nextUrl);
+  const actualRedirectUrl = new URL(preferredRedirectUrl.pathname + preferredRedirectUrl.search, req.nextUrl);
 
   const response = NextResponse.redirect(actualRedirectUrl);
 


### PR DESCRIPTION
This PR fixes a bug in the dev-mode-callback page. Today, that page does not restore URL search parameters, only URL paths. This PR includes search parameters as part of the set of data we restore.

For completeness' sake, note that the URL fragment is not possible to restore, because redirecting to the login page happens primarily from the server, where fragments are not known to the server.